### PR TITLE
chore: go-demo-6 to 2.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: go-demo-6
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.0.0
+  version: 2.0.1


### PR DESCRIPTION
chore: Promote go-demo-6 to version 2.0.1